### PR TITLE
Convert Date object to timestamp when saving new Release

### DIFF
--- a/public/javascripts/releases-controllers.js
+++ b/public/javascripts/releases-controllers.js
@@ -252,7 +252,7 @@
             var NewRelease = function() {
                 return {
                     name: '',
-                    releaseDate: new Date().getTime(),
+                    releaseDate: new Date(),
                     tickets: []
                 };
             };
@@ -271,6 +271,10 @@
             $scope.submit = function(isValid) {
                 if (true !== isValid) {
                     return;
+                }
+                if ($scope.release.releaseDate instanceof Date)
+                {
+                    $scope.release.releaseDate = $scope.release.releaseDate.getTime();
                 }
                 Releases.$add($scope.release)
                         .then(function(ref) {


### PR DESCRIPTION
Fixes #6 

When creating a release and the date is altered in the datepicker, release.releaseDate is set to an instance of Date(). The conversion to timestamp with getTime() was never carried out and so was not being correctly saved to the firebase.
