### PR TITLE
Fix release cut off check

### DIFF
--- a/public/javascripts/releases-controllers.js
+++ b/public/javascripts/releases-controllers.js
@@ -34,7 +34,7 @@
             if ([2, 3, 4, 5, 6].indexOf(cutOffDate.getDay()) >= 0) {
                 // Tuesday -> Saturday uses yesterday
                 cutOffDate.setDate(cutOffDate.getDate() - 1);
-            } else if (cutOffDate.getDay() == 7) {
+            } else if (cutOffDate.getDay() === 0) {
                 //Sunday uses previous friday
                 cutOffDate.setDate(cutOffDate.getDate() - 2);
             } else {
@@ -48,7 +48,7 @@
             };
 
             var pastCutOff = function() {
-                return (new Date()).getHours() >= 14;
+                return (new Date()) >= cutOffDate;
             };
             var cutOffUpdateInterval = 10 * 1000;
             var updatePastCutOff = function() {


### PR DESCRIPTION
Previously the cut off warning would always appear if the current hour
was 14 or higher. This meant that a release two or more days into the
future could show the warning prematurely (e.g. we should be able to add
tickets to a release on Wednesday after 2pm on Monday but the warning
was still showing).

Now, the cut off warning actually takes into account the date of the
release and only shows the warning after 2pm on the last working day
before the release.