### PR TITLE
Remove empty diff requirements

### DIFF
--- a/public/javascripts/releases-controllers.js
+++ b/public/javascripts/releases-controllers.js
@@ -244,7 +244,8 @@
 
             // Remove empty requirements
             for (var key in $scope.newDiff.requirements) {
-                if (!$scope.newDiff.requirements[key]) {
+                if ($scope.newDiff.requirements.hasOwnProperty(key) &&
+                    !$scope.newDiff.requirements[key]) {
                     delete $scope.newDiff.requirements[key];
                 }
             }

--- a/public/javascripts/releases-controllers.js
+++ b/public/javascripts/releases-controllers.js
@@ -228,7 +228,7 @@
                 "released": false,
                 "rolledBack": false,
                 "repoName": '',
-                "requirents": {
+                "requirements": {
                 }
             };
         };
@@ -241,6 +241,14 @@
             if ('undefined' === typeof(ticket.diffs)) {
                 ticket.diffs = [];
             }
+
+            // Remove empty requirements
+            for (var key in $scope.newDiff.requirements) {
+                if (!$scope.newDiff.requirements[key]) {
+                    delete $scope.newDiff.requirements[key];
+                }
+            }
+
             $scope.newDiff.created = Date.now();
             ticket.diffs.push($scope.newDiff);
             release.$save().then(function() {

--- a/views/partials/release-ticket-diff-add.jade
+++ b/views/partials/release-ticket-diff-add.jade
@@ -108,5 +108,5 @@ div(class='modal-footer')
     class='btn btn-primary',
     ng-click='submit(addDiff.$valid)',
     ng-disabled='addDiff.$invalid'
-  ) Add ticket
+  ) Add Diff
   button(class='btn btn-warning', type='button', ng-click='cancel()') Cancel


### PR DESCRIPTION
If a diff requirement is edited in the Add Diff form and reverted before submission, it would still be present to in the requirements object.
This could cause the "Requirements" button to appear when viewing a diff with no requirements.
Unchecked or empty requirements will now be removed before saving to the firebase.

Also fixes:
 - Mispelt key in diff initialisation
 - Incorrect submit button text on Add Diff form