### PR TITLE
Improve productionConfigs label on Add Diff

### DIFF
--- a/views/partials/release-ticket-diff-add.jade
+++ b/views/partials/release-ticket-diff-add.jade
@@ -74,7 +74,7 @@ div(class='modal-body')
             type='checkbox',
             ng-model='newDiff.requirements.productionConfigs'
           )
-          | Production Configs
+          | Production Hiera Configs
     div(class='form-group')
       label(class='control-label checkbox-inline col-sm-2') &nbsp;
       div(class="checkbox")


### PR DESCRIPTION
A diff with productionConfigs requirement will display 'Production Hiera Configs',
the option on the 'Add Diff' form will now match this.