### PR TITLE
Allow audit URLs to be used instead of diffs

### DIFF
--- a/public/javascripts/releases-controllers.js
+++ b/public/javascripts/releases-controllers.js
@@ -34,7 +34,7 @@
             if ([2, 3, 4, 5, 6].indexOf(cutOffDate.getDay()) >= 0) {
                 // Tuesday -> Saturday uses yesterday
                 cutOffDate.setDate(cutOffDate.getDate() - 1);
-            } else if (cutOffDate.getDay() == 7) {
+            } else if (cutOffDate.getDay() === 0) {
                 //Sunday uses previous friday
                 cutOffDate.setDate(cutOffDate.getDate() - 2);
             } else {
@@ -48,7 +48,7 @@
             };
 
             var pastCutOff = function() {
-                return (new Date()).getHours() >= 14;
+                return (new Date()) >= cutOffDate;
             };
             var cutOffUpdateInterval = 10 * 1000;
             var updatePastCutOff = function() {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -7,10 +7,15 @@ body { padding-top: 50px; }
 }
 
 /** angular-ui */
-.nav, .pagination, .carousel, .panel-title a { 
-    cursor: pointer; 
+.nav, .pagination, .carousel, .panel-title a {
+    cursor: pointer;
 }
 
 .diff-row {
     margin-bottom: 15px;
+}
+
+.diff-link {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }

--- a/views/partials/release-ticket-diff-add.jade
+++ b/views/partials/release-ticket-diff-add.jade
@@ -9,12 +9,12 @@ div(class='modal-body')
     ng-submit='submit(addDiff.$valid)'
   )
     div(class='form-group')
-      label(class='control-label col-sm-2') Phabricator Diff
+      label(class='control-label col-sm-2') Phabricator Diff/Audit
       div(class='col-sm-10')
         input(
           type='text',
           class='form-control',
-          placeholder='D####',
+          placeholder='D#### or r[REPO][commit hash]',
           required,
           ng-model='newDiff.diffId'
         )

--- a/views/partials/release-ticket-diff-add.jade
+++ b/views/partials/release-ticket-diff-add.jade
@@ -9,7 +9,7 @@ div(class='modal-body')
     ng-submit='submit(addDiff.$valid)'
   )
     div(class='form-group')
-      label(class='control-label col-sm-2') Phabricator Diff/Audit
+      label(class='control-label col-sm-2') Phabricator Diff/Commit
       div(class='col-sm-10')
         input(
           type='text',

--- a/views/partials/release-view.jade
+++ b/views/partials/release-view.jade
@@ -65,7 +65,7 @@ div(ng-show="release")
             ng-show='diff.repoName',
             title='Added {{ diff.created | date:"EEEE, MMMM d yyyy HH:mm:ss" }}'
           ) {{diff.repoName}}
-        div(class='col-sm-2', ng-class='{"text-muted": diff.released}')
+        div(class='col-sm-2 diff-link', ng-class='{"text-muted": diff.released}')
           a(href='http://phab.dev.ebuyer.com/{{diff.diffId}}') {{diff.diffId}}
         div(class='col-sm-2', ng-class='{"text-success": diff.released && !diff.rolledBack}')
           span(ng-show='diff.released && !diff.rolledBack')


### PR DESCRIPTION
Sometimes, we need to release quick fixes that were not reviewed. We still want to add these to the release app for visibility and, rather than linking to nothing, we can link to the audit on phab.

For example, link to http://phab.dev.ebuyer.com/rGENONEfcc395703a1f8edee04db518ed56c121705900fe rather than http://phab.dev.ebuyer.com/D5610

This patch updates the Add Diff form to indicate this possibility, and improves the styling of the release view so that lengthy commit hashes do not overflow other elements of a release (such as the Release button/Released status text).
